### PR TITLE
Discard master-slave jargon

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,8 +50,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'nova'

--- a/jacket/api/openstack/wsgi.py
+++ b/jacket/api/openstack/wsgi.py
@@ -510,7 +510,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/jacket/api/storage/contrib/extended_snapshot_attributes.py
+++ b/jacket/api/storage/contrib/extended_snapshot_attributes.py
@@ -38,7 +38,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['storage.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedSnapshotAttributeTemplate())
             snapshot = resp_obj.obj['snapshot']
             self._extend_snapshot(req, snapshot)
@@ -47,7 +47,7 @@ class ExtendedSnapshotAttributesController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['storage.context']
         if authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=ExtendedSnapshotAttributesTemplate())
             for snapshot in list(resp_obj.obj['snapshots']):
                 self._extend_snapshot(req, snapshot)
@@ -82,7 +82,7 @@ class ExtendedSnapshotAttributeTemplate(xmlutil.TemplateBuilder):
         make_snapshot(root)
         alias = Extended_snapshot_attributes.alias
         namespace = Extended_snapshot_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class ExtendedSnapshotAttributesTemplate(xmlutil.TemplateBuilder):
@@ -93,4 +93,4 @@ class ExtendedSnapshotAttributesTemplate(xmlutil.TemplateBuilder):
         make_snapshot(elem)
         alias = Extended_snapshot_attributes.alias
         namespace = Extended_snapshot_attributes.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})

--- a/jacket/api/storage/contrib/volume_type_access.py
+++ b/jacket/api/storage/contrib/volume_type_access.py
@@ -46,7 +46,7 @@ class VolumeTypeTemplate(xmlutil.TemplateBuilder):
         make_volume_type(root)
         alias = Volume_type_access.alias
         namespace = Volume_type_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class VolumeTypesTemplate(xmlutil.TemplateBuilder):
@@ -57,7 +57,7 @@ class VolumeTypesTemplate(xmlutil.TemplateBuilder):
         make_volume_type(elem)
         alias = Volume_type_access.alias
         namespace = Volume_type_access.namespace
-        return xmlutil.SlaveTemplate(root, 1, nsmap={alias: namespace})
+        return xmlutil.SubordinateTemplate(root, 1, nsmap={alias: namespace})
 
 
 class VolumeTypeAccessTemplate(xmlutil.TemplateBuilder):
@@ -66,7 +66,7 @@ class VolumeTypeAccessTemplate(xmlutil.TemplateBuilder):
         elem = xmlutil.SubTemplateElement(root, 'access',
                                           selector='volume_type_access')
         make_volume_type_access(elem)
-        return xmlutil.MasterTemplate(root, 1)
+        return xmlutil.MainTemplate(root, 1)
 
 
 def _marshall_volume_type_access(vol_type):
@@ -123,7 +123,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def show(self, req, resp_obj, id):
         context = req.environ['storage.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypeTemplate())
             vol_type = req.cached_resource_by_id(id, name='types')
             self._extend_vol_type(resp_obj.obj['volume_type'], vol_type)
@@ -132,7 +132,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def index(self, req, resp_obj):
         context = req.environ['storage.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypesTemplate())
             for vol_type_rval in list(resp_obj.obj['volume_types']):
                 type_id = vol_type_rval['id']
@@ -143,7 +143,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def detail(self, req, resp_obj):
         context = req.environ['storage.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypesTemplate())
             for vol_type_rval in list(resp_obj.obj['volume_types']):
                 type_id = vol_type_rval['id']
@@ -154,7 +154,7 @@ class VolumeTypeActionController(wsgi.Controller):
     def create(self, req, body, resp_obj):
         context = req.environ['storage.context']
         if soft_authorize(context):
-            # Attach our slave template to the response object
+            # Attach our subordinate template to the response object
             resp_obj.attach(xml=VolumeTypeTemplate())
             type_id = resp_obj.obj['volume_type']['id']
             vol_type = req.cached_resource_by_id(type_id, name='types')

--- a/jacket/api/storage/openstack/wsgi.py
+++ b/jacket/api/storage/openstack/wsgi.py
@@ -720,7 +720,7 @@ class ResponseObject(object):
         self.serializer = serializer()
 
     def attach(self, **kwargs):
-        """Attach slave templates to serializers."""
+        """Attach subordinate templates to serializers."""
 
         if self.media_type in kwargs:
             self.serializer.attach(kwargs[self.media_type])

--- a/jacket/api/storage/xmlutil.py
+++ b/jacket/api/storage/xmlutil.py
@@ -701,13 +701,13 @@ class Template(object):
         # We are a template
         return self
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.
+        is applicable as a subordinate to a given main template.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
         return True
@@ -722,17 +722,17 @@ class Template(object):
         return "%r: %s" % (self, self.root.tree())
 
 
-class MasterTemplate(Template):
-    """Represent a master template.
+class MainTemplate(Template):
+    """Represent a main template.
 
-    Master templates are versioned derivatives of templates that
-    additionally allow slave templates to be attached.  Slave
+    Main templates are versioned derivatives of templates that
+    additionally allow subordinate templates to be attached.  Subordinate
     templates allow modification of the serialized result without
-    directly changing the master.
+    directly changing the main.
     """
 
     def __init__(self, root, version, nsmap=None):
-        """Initialize a master template.
+        """Initialize a main template.
 
         :param root: The root element of the template.
         :param version: The version number of the template.
@@ -741,9 +741,9 @@ class MasterTemplate(Template):
                       template.
         """
 
-        super(MasterTemplate, self).__init__(root, nsmap)
+        super(MainTemplate, self).__init__(root, nsmap)
         self.version = version
-        self.slaves = []
+        self.subordinates = []
 
     def __repr__(self):
         """Return string representation of the template."""
@@ -757,89 +757,89 @@ class MasterTemplate(Template):
 
         An overridable hook method to return the siblings of the root
         element.  This is the root element plus the root elements of
-        all the slave templates.
+        all the subordinate templates.
         """
 
-        return [self.root] + [slave.root for slave in self.slaves]
+        return [self.root] + [subordinate.root for subordinate in self.subordinates]
 
     def _nsmap(self):
         """Hook method for computing the namespace dictionary.
 
         An overridable hook method to return the namespace dictionary.
-        The namespace dictionary is computed by taking the master
+        The namespace dictionary is computed by taking the main
         template's namespace dictionary and updating it from all the
-        slave templates.
+        subordinate templates.
         """
 
         nsmap = self.nsmap.copy()
-        for slave in self.slaves:
-            nsmap.update(slave._nsmap())
+        for subordinate in self.subordinates:
+            nsmap.update(subordinate._nsmap())
         return nsmap
 
-    def attach(self, *slaves):
-        """Attach one or more slave templates.
+    def attach(self, *subordinates):
+        """Attach one or more subordinate templates.
 
-        Attaches one or more slave templates to the master template.
-        Slave templates must have a root element with the same tag as
-        the master template.  The slave template's apply() method will
-        be called to determine if the slave should be applied to this
-        master; if it returns False, that slave will be skipped.
-        (This allows filtering of slaves based on the version of the
-        master template.)
+        Attaches one or more subordinate templates to the main template.
+        Subordinate templates must have a root element with the same tag as
+        the main template.  The subordinate template's apply() method will
+        be called to determine if the subordinate should be applied to this
+        main; if it returns False, that subordinate will be skipped.
+        (This allows filtering of subordinates based on the version of the
+        main template.)
         """
 
-        slave_list = []
-        for slave in slaves:
-            slave = slave.wrap()
+        subordinate_list = []
+        for subordinate in subordinates:
+            subordinate = subordinate.wrap()
 
             # Make sure we have a tree match
-            if slave.root.tag != self.root.tag:
-                msg = (_("Template tree mismatch; adding slave %(slavetag)s "
-                         "to master %(mastertag)s") %
-                       {'slavetag': slave.root.tag,
-                        'mastertag': self.root.tag})
+            if subordinate.root.tag != self.root.tag:
+                msg = (_("Template tree mismatch; adding subordinate %(subordinatetag)s "
+                         "to main %(maintag)s") %
+                       {'subordinatetag': subordinate.root.tag,
+                        'maintag': self.root.tag})
                 raise ValueError(msg)
 
-            # Make sure slave applies to this template
-            if not slave.apply(self):
+            # Make sure subordinate applies to this template
+            if not subordinate.apply(self):
                 continue
 
-            slave_list.append(slave)
+            subordinate_list.append(subordinate)
 
-        # Add the slaves
-        self.slaves.extend(slave_list)
+        # Add the subordinates
+        self.subordinates.extend(subordinate_list)
 
     def copy(self):
-        """Return a copy of this master template."""
+        """Return a copy of this main template."""
 
-        # Return a copy of the MasterTemplate
+        # Return a copy of the MainTemplate
         tmp = self.__class__(self.root, self.version, self.nsmap)
-        tmp.slaves = self.slaves[:]
+        tmp.subordinates = self.subordinates[:]
         return tmp
 
 
-class SlaveTemplate(Template):
-    """Represent a slave template.
+class SubordinateTemplate(Template):
+    """Represent a subordinate template.
 
-    Slave templates are versioned derivatives of templates.  Each
-    slave has a minimum version and optional maximum version of the
-    master template to which they can be attached.
+    Subordinate templates are versioned derivatives of templates.  Each
+    subordinate has a minimum version and optional maximum version of the
+    main template to which they can be attached.
     """
 
     def __init__(self, root, min_vers, max_vers=None, nsmap=None):
-        """Initialize a slave template.
+        """Initialize a subordinate template.
 
         :param root: The root element of the template.
-        :param min_vers: The minimum permissible version of the master
-                         template for this slave template to apply.
-        :param max_vers: An optional upper bound for the master
+        :param min_vers: The minimum permissible version of the main
+                         template for this subordinate template to apply.
+        :param max_vers: An optional upper bound for the main
                          template version.
         :param nsmap: An optional namespace dictionary to be
                       associated with the root element of the
                       template.
         """
 
-        super(SlaveTemplate, self).__init__(root, nsmap)
+        super(SubordinateTemplate, self).__init__(root, nsmap)
         self.min_vers = min_vers
         self.max_vers = max_vers
 
@@ -850,23 +850,23 @@ class SlaveTemplate(Template):
                 (self.__class__.__module__, self.__class__.__name__,
                  self.min_vers, self.max_vers, id(self)))
 
-    def apply(self, master):
-        """Hook method for determining slave applicability.
+    def apply(self, main):
+        """Hook method for determining subordinate applicability.
 
         An overridable hook method used to determine if this template
-        is applicable as a slave to a given master template.  This
-        version requires the master template to have a version number
+        is applicable as a subordinate to a given main template.  This
+        version requires the main template to have a version number
         between min_vers and max_vers.
 
-        :param master: The master template to test.
+        :param main: The main template to test.
         """
 
-        # Does the master meet our minimum version requirement?
-        if master.version < self.min_vers:
+        # Does the main meet our minimum version requirement?
+        if main.version < self.min_vers:
             return False
 
         # How about our maximum version requirement?
-        if self.max_vers is not None and master.version > self.max_vers:
+        if self.max_vers is not None and main.version > self.max_vers:
             return False
 
         return True

--- a/jacket/compute/cloud/manager.py
+++ b/jacket/compute/cloud/manager.py
@@ -817,7 +817,7 @@ class ComputeManager(manager.Manager):
                 return objects.InstanceList()
             filters['uuid'] = driver_uuids
             local_instances = objects.InstanceList.get_by_filters(
-                context, filters, use_slave=True)
+                context, filters, use_subordinate=True)
             return local_instances
         except NotImplementedError:
             pass
@@ -826,7 +826,7 @@ class ComputeManager(manager.Manager):
         # to brute force.
         driver_instances = self.driver.list_instances()
         instances = objects.InstanceList.get_by_filters(context, filters,
-                                                        use_slave=True)
+                                                        use_subordinate=True)
         name_map = {instance.name: instance for instance in instances}
         local_instances = []
         for driver_instance in driver_instances:
@@ -1896,7 +1896,7 @@ class ComputeManager(manager.Manager):
     #     context = context.elevated()
     #     instances = cloud.InstanceList.get_by_host(context, self.host,
     #                                                  expected_attrs=[],
-    #                                                  use_slave=True)
+    #                                                  use_subordinate=True)
     #     uuids = [instance.uuid for instance in instances]
     #     self.scheduler_client.sync_instance_info(context, self.host, uuids)
 
@@ -5968,11 +5968,11 @@ class ComputeManager(manager.Manager):
                 self._set_instance_obj_error_state(context, instance)
 
     @wrap_exception()
-    def add_aggregate_host(self, context, aggregate, host, slave_info):
+    def add_aggregate_host(self, context, aggregate, host, subordinate_info):
         """Notify hypervisor of change (for hypervisor pools)."""
         try:
             self.driver.add_to_aggregate(context, aggregate, host,
-                                         slave_info=slave_info)
+                                         subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'add_aggregate_host')
@@ -5984,11 +5984,11 @@ class ComputeManager(manager.Manager):
                     aggregate, host)
 
     @wrap_exception()
-    def remove_aggregate_host(self, context, host, slave_info, aggregate):
+    def remove_aggregate_host(self, context, host, subordinate_info, aggregate):
         """Removes a host from a physical hypervisor pool."""
         try:
             self.driver.remove_from_aggregate(context, aggregate, host,
-                                              slave_info=slave_info)
+                                              subordinate_info=subordinate_info)
         except NotImplementedError:
             LOG.debug('Hypervisor driver does not support '
                       'remove_aggregate_host')

--- a/jacket/compute/cloud/rpcapi.py
+++ b/jacket/compute/cloud/rpcapi.py
@@ -162,7 +162,7 @@ class ComputeAPI(object):
 
         * 2.0 - Remove 1.x backwards compat
         * 2.1 - Adds orig_sys_metadata to rebuild_instance()
-        * 2.2 - Adds slave_info parameter to add_aggregate_host() and
+        * 2.2 - Adds subordinate_info parameter to add_aggregate_host() and
                 remove_aggregate_host()
         * 2.3 - Adds volume_id to reserve_block_device_name()
         * 2.4 - Add bdms to terminate_instance
@@ -390,7 +390,7 @@ class ComputeAPI(object):
                               serializer=serializer)
 
     def add_aggregate_host(self, ctxt, aggregate, host_param, host,
-                           slave_info=None):
+                           subordinate_info=None):
         '''Add aggregate host.
 
         :param ctxt: request context
@@ -403,7 +403,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'add_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def add_fixed_ip_to_instance(self, ctxt, instance, network_id):
         version = '4.0'
@@ -759,7 +759,7 @@ class ComputeAPI(object):
                    **extra)
 
     def remove_aggregate_host(self, ctxt, aggregate, host_param, host,
-                              slave_info=None):
+                              subordinate_info=None):
         '''Remove aggregate host.
 
         :param ctxt: request context
@@ -772,7 +772,7 @@ class ComputeAPI(object):
         cctxt = self.client.prepare(server=host, version=version)
         cctxt.cast(ctxt, 'remove_aggregate_host',
                    aggregate=aggregate, host=host_param,
-                   slave_info=slave_info)
+                   subordinate_info=subordinate_info)
 
     def remove_fixed_ip_from_instance(self, ctxt, instance, address):
         version = '4.0'

--- a/jacket/compute/conductor/rpcapi.py
+++ b/jacket/compute/conductor/rpcapi.py
@@ -126,7 +126,7 @@ class ConductorAPI(object):
     * 1.62 - Added object_backport()
     * 1.63 - Changed the format of values['stats'] from a dict to a JSON string
              in compute_node_update()
-    * 1.64 - Added use_slave to instance_get_all_filters()
+    * 1.64 - Added use_subordinate to instance_get_all_filters()
            - Remove instance_type_get()
            - Remove aggregate_get()
            - Remove aggregate_get_by_host()

--- a/jacket/compute/console/xvp.py
+++ b/jacket/compute/console/xvp.py
@@ -40,7 +40,7 @@ xvp_opts = [
                help='Generated XVP conf file'),
     cfg.StrOpt('console_xvp_pid',
                default='/var/run/xvp.pid',
-               help='XVP master process pid file'),
+               help='XVP main process pid file'),
     cfg.StrOpt('console_xvp_log',
                default='/var/log/xvp.log',
                help='XVP log file'),

--- a/jacket/compute/network/ldapdns.py
+++ b/jacket/compute/network/ldapdns.py
@@ -42,9 +42,9 @@ ldap_dns_opts = [
                default='password',
                help='Password for LDAP DNS',
                secret=True),
-    cfg.StrOpt('ldap_dns_soa_hostmaster',
-               default='hostmaster@example.org',
-               help='Hostmaster for LDAP DNS driver Statement of Authority'),
+    cfg.StrOpt('ldap_dns_soa_hostmain',
+               default='hostmain@example.org',
+               help='Hostmain for LDAP DNS driver Statement of Authority'),
     cfg.MultiStrOpt('ldap_dns_servers',
                     default=['dns.example.org'],
                     help='DNS Servers for LDAP DNS driver'),
@@ -156,7 +156,7 @@ class DomainEntry(DNSEntry):
         date = time.strftime('%Y%m%d%H%M%S')
         soa = '%s %s %s %s %s %s %s' % (
                  CONF.ldap_dns_servers[0],
-                 CONF.ldap_dns_soa_hostmaster,
+                 CONF.ldap_dns_soa_hostmain,
                  date,
                  CONF.ldap_dns_soa_refresh,
                  CONF.ldap_dns_soa_retry,

--- a/jacket/compute/network/linux_net.py
+++ b/jacket/compute/network/linux_net.py
@@ -1650,7 +1650,7 @@ class LinuxBridgeInterfaceDriver(LinuxNetInterfaceDriver):
             out, err = _execute('brctl', 'addif', bridge, interface,
                                 check_exit_code=False, run_as_root=True)
             if (err and err != "device %s is already a member of a bridge; "
-                     "can't enslave it to bridge %s.\n" % (interface, bridge)):
+                     "can't ensubordinate it to bridge %s.\n" % (interface, bridge)):
                 msg = _('Failed to add interface: %s') % err
                 raise exception.NovaException(msg)
 

--- a/jacket/db/compute/api.py
+++ b/jacket/db/compute/api.py
@@ -98,8 +98,8 @@ def create_context_manager(connection):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
     """
     return IMPL.select_db_reader_mode(f)
 

--- a/jacket/db/compute/sqlalchemy/api.py
+++ b/jacket/db/compute/sqlalchemy/api.py
@@ -85,10 +85,10 @@ api_db_opts = [
     cfg.BoolOpt('sqlite_synchronous',
                 default=True,
                 help='If True, SQLite uses synchronous mode.'),
-    cfg.StrOpt('slave_connection',
+    cfg.StrOpt('subordinate_connection',
                secret=True,
                help='The SQLAlchemy connection string to use to connect to the'
-                    ' slave database.'),
+                    ' subordinate database.'),
     cfg.StrOpt('mysql_sql_mode',
                default='TRADITIONAL',
                help='The SQL mode to be used for MySQL sessions. '
@@ -140,7 +140,7 @@ api_context_manager = enginefacade.transaction_context()
 def _get_db_conf(conf_group, connection=None):
     kw = dict(
         connection=connection or conf_group.connection,
-        slave_connection=conf_group.slave_connection,
+        subordinate_connection=conf_group.subordinate_connection,
         sqlite_fk=False,
         __autocommit=True,
         expire_on_commit=False,
@@ -188,14 +188,14 @@ def get_context_manager(context):
     return _context_manager_from_context(context) or main_context_manager
 
 
-def get_engine(use_slave=False, context=None):
+def get_engine(use_subordinate=False, context=None):
     """Get a database engine object.
 
-    :param use_slave: Whether to use the slave connection
+    :param use_subordinate: Whether to use the subordinate connection
     :param context: The request context that can contain a context manager
     """
     ctxt_mgr = _context_manager_from_context(context) or main_context_manager
-    return ctxt_mgr.get_legacy_facade().get_engine(use_slave=use_slave)
+    return ctxt_mgr.get_legacy_facade().get_engine(use_subordinate=use_subordinate)
 
 
 def get_api_engine():
@@ -261,9 +261,9 @@ def require_aggregate_exists(f):
 def select_db_reader_mode(f):
     """Decorator to select synchronous or asynchronous reader mode.
 
-    The kwarg argument 'use_slave' defines reader mode. Asynchronous reader
-    will be used if 'use_slave' is True and synchronous reader otherwise.
-    If 'use_slave' is not specified default value 'False' will be used.
+    The kwarg argument 'use_subordinate' defines reader mode. Asynchronous reader
+    will be used if 'use_subordinate' is True and synchronous reader otherwise.
+    If 'use_subordinate' is not specified default value 'False' will be used.
 
     Wrapped function must have a context in the arguments.
     """
@@ -274,9 +274,9 @@ def select_db_reader_mode(f):
         keyed_args = inspect.getcallargs(wrapped_func, *args, **kwargs)
 
         context = keyed_args['context']
-        use_slave = keyed_args.get('use_slave', False)
+        use_subordinate = keyed_args.get('use_subordinate', False)
 
-        if use_slave:
+        if use_subordinate:
             reader_mode = main_context_manager.async
         else:
             reader_mode = main_context_manager.reader
@@ -6407,7 +6407,7 @@ def archive_deleted_rows(max_rows=None):
     """
     table_to_rows_archived = {}
     total_rows_archived = 0
-    meta = MetaData(get_engine(use_slave=True))
+    meta = MetaData(get_engine(use_subordinate=True))
     meta.reflect()
     # Reverse sort the tables so we get the leaf nodes first for processing.
     for table in reversed(meta.sorted_tables):

--- a/jacket/objects/compute/bandwidth_usage.py
+++ b/jacket/objects/compute/bandwidth_usage.py
@@ -20,7 +20,7 @@ from jacket.objects.compute import fields
 class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
                      base.NovaObjectDictCompat):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_instance_uuid_and_mac
+    # Version 1.1: Add use_subordinate to get_by_instance_uuid_and_mac
     # Version 1.2: Add update_cells to create
     VERSION = '1.2'
 
@@ -48,17 +48,17 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_bw_usage_get(context, uuid, start_period, mac, use_slave=False):
+    def _db_bw_usage_get(context, uuid, start_period, mac, use_subordinate=False):
         return db.bw_usage_get(context, uuid=uuid, start_period=start_period,
                                mac=mac)
 
     @base.serialize_args
     @base.remotable_classmethod
     def get_by_instance_uuid_and_mac(cls, context, instance_uuid, mac,
-                                     start_period=None, use_slave=False):
+                                     start_period=None, use_subordinate=False):
         db_bw_usage = cls._db_bw_usage_get(context, uuid=instance_uuid,
                                       start_period=start_period, mac=mac,
-                                      use_slave=use_slave)
+                                      use_subordinate=use_subordinate)
         if db_bw_usage:
             return cls._from_db_object(context, cls(), db_bw_usage)
 
@@ -78,7 +78,7 @@ class BandwidthUsage(base.NovaPersistentObject, base.NovaObject,
 @base.NovaObjectRegistry.register
 class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
-    # Version 1.1: Add use_slave to get_by_uuids
+    # Version 1.1: Add use_subordinate to get_by_uuids
     # Version 1.2: BandwidthUsage <= version 1.2
     VERSION = '1.2'
     fields = {
@@ -88,14 +88,14 @@ class BandwidthUsageList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_bw_usage_get_by_uuids(context, uuids, start_period,
-                                  use_slave=False):
+                                  use_subordinate=False):
         return db.bw_usage_get_by_uuids(context, uuids=uuids,
                                         start_period=start_period)
 
     @base.serialize_args
     @base.remotable_classmethod
-    def get_by_uuids(cls, context, uuids, start_period=None, use_slave=False):
+    def get_by_uuids(cls, context, uuids, start_period=None, use_subordinate=False):
         db_bw_usages = cls._db_bw_usage_get_by_uuids(context, uuids=uuids,
                                                 start_period=start_period,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(), BandwidthUsage, db_bw_usages)

--- a/jacket/objects/compute/block_device.py
+++ b/jacket/objects/compute/block_device.py
@@ -287,7 +287,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
 class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: BlockDeviceMapping <= version 1.1
-    # Version 1.2: Added use_slave to get_by_instance_uuid
+    # Version 1.2: Added use_subordinate to get_by_instance_uuid
     # Version 1.3: BlockDeviceMapping <= version 1.2
     # Version 1.4: BlockDeviceMapping <= version 1.3
     # Version 1.5: BlockDeviceMapping <= version 1.4
@@ -325,28 +325,28 @@ class BlockDeviceMappingList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=False):
+            context, instance_uuids, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance_uuids(
                 context, instance_uuids)
 
     @base.remotable_classmethod
-    def get_by_instance_uuids(cls, context, instance_uuids, use_slave=False):
+    def get_by_instance_uuids(cls, context, instance_uuids, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance_uuids(
-            context, instance_uuids, use_slave=use_slave)
+            context, instance_uuids, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 
     @staticmethod
     @db.select_db_reader_mode
     def _db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=False):
+            context, instance_uuid, use_subordinate=False):
         return db.block_device_mapping_get_all_by_instance(
             context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_bdms = cls._db_block_device_mapping_get_all_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(
                 context, cls(), objects.BlockDeviceMapping, db_bdms or [])
 

--- a/jacket/objects/compute/compute_node.py
+++ b/jacket/objects/compute/compute_node.py
@@ -272,8 +272,8 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject,
     # TODO(pkholkin): Remove this method in the next major version bump
     @base.remotable_classmethod
     def get_first_node_by_host_for_old_compat(cls, context, host,
-                                              use_slave=False):
-        computes = ComputeNodeList.get_all_by_host(context, host, use_slave)
+                                              use_subordinate=False):
+        computes = ComputeNodeList.get_all_by_host(context, host, use_subordinate)
         # FIXME(sbauza): Some hypervisors (VMware, Ironic) can return multiple
         # nodes per host, we should return all the nodes and modify the callers
         # instead.
@@ -370,7 +370,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # Version 1.2 Add get_by_service()
     # Version 1.3 ComputeNode version 1.4
     # Version 1.4 ComputeNode version 1.5
-    # Version 1.5 Add use_slave to get_by_service
+    # Version 1.5 Add use_subordinate to get_by_service
     # Version 1.6 ComputeNode version 1.6
     # Version 1.7 ComputeNode version 1.7
     # Version 1.8 ComputeNode version 1.8 + add get_all_by_host()
@@ -401,7 +401,7 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
     # NOTE(hanlind): This is deprecated and should be removed on the next
     # major version bump
     @base.remotable_classmethod
-    def _get_by_service(cls, context, service_id, use_slave=False):
+    def _get_by_service(cls, context, service_id, use_subordinate=False):
         try:
             db_computes = db.compute_nodes_get_by_service_id(
                 context, service_id)
@@ -414,12 +414,12 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_compute_node_get_all_by_host(context, host, use_slave=False):
+    def _db_compute_node_get_all_by_host(context, host, use_subordinate=False):
         return db.compute_node_get_all_by_host(context, host)
 
     @base.remotable_classmethod
-    def get_all_by_host(cls, context, host, use_slave=False):
+    def get_all_by_host(cls, context, host, use_subordinate=False):
         db_computes = cls._db_compute_node_get_all_by_host(context, host,
-                                                      use_slave=use_slave)
+                                                      use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.ComputeNode,
                                   db_computes)

--- a/jacket/objects/compute/instance.py
+++ b/jacket/objects/compute/instance.py
@@ -386,17 +386,17 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                 use_slave=False):
+                                 use_subordinate=False):
         return db.instance_get_by_uuid(context, uuid,
                                        columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_slave=False):
+    def get_by_uuid(cls, context, uuid, expected_attrs=None, use_subordinate=False):
         if expected_attrs is None:
             expected_attrs = ['info_cache', 'security_groups']
         columns_to_join = _expected_cols(expected_attrs)
         db_inst = cls._db_instance_get_by_uuid(context, uuid, columns_to_join,
-                                               use_slave=use_slave)
+                                               use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_inst,
                                    expected_attrs)
 
@@ -728,12 +728,12 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         self.obj_reset_changes()
 
     @base.remotable
-    def refresh(self, use_slave=False):
+    def refresh(self, use_subordinate=False):
         extra = [field for field in INSTANCE_OPTIONAL_ATTRS
                        if self.obj_attr_is_set(field)]
         current = self.__class__.get_by_uuid(self._context, uuid=self.uuid,
                                              expected_attrs=extra,
-                                             use_slave=use_slave)
+                                             use_subordinate=use_subordinate)
         # NOTE(danms): We orphan the instance copy so we do not unexpectedly
         # trigger a lazy-load (which would mean we failed to calculate the
         # expected_attrs properly)
@@ -1040,7 +1040,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _get_by_filters_impl(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         if sort_keys or sort_dirs:
             db_inst_list = db.instance_get_all_by_filters_sort(
@@ -1057,25 +1057,25 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @base.remotable_classmethod
     def get_by_filters(cls, context, filters,
                        sort_key='created_at', sort_dir='desc', limit=None,
-                       marker=None, expected_attrs=None, use_slave=False,
+                       marker=None, expected_attrs=None, use_subordinate=False,
                        sort_keys=None, sort_dirs=None):
         return cls._get_by_filters_impl(
             context, filters, sort_key=sort_key, sort_dir=sort_dir,
             limit=limit, marker=marker, expected_attrs=expected_attrs,
-            use_slave=use_slave, sort_keys=sort_keys, sort_dirs=sort_dirs)
+            use_subordinate=use_subordinate, sort_keys=sort_keys, sort_dirs=sort_dirs)
 
     @staticmethod
     @db.select_db_reader_mode
     def _db_instance_get_all_by_host(context, host, columns_to_join,
-                                     use_slave=False):
+                                     use_subordinate=False):
         return db.instance_get_all_by_host(context, host,
                                            columns_to_join=columns_to_join)
 
     @base.remotable_classmethod
-    def get_by_host(cls, context, host, expected_attrs=None, use_slave=False):
+    def get_by_host(cls, context, host, expected_attrs=None, use_subordinate=False):
         db_inst_list = cls._db_instance_get_all_by_host(
             context, host, columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
@@ -1115,7 +1115,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     @db.select_db_reader_mode
     def _db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host, columns_to_join,
-            use_slave=False):
+            use_subordinate=False):
         return db.instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=columns_to_join)
@@ -1124,7 +1124,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     def _get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         # NOTE(mriedem): We need to convert the begin/end timestamp strings
         # to timezone-aware datetime objects for the DB API call.
         begin = timeutils.parse_isotime(begin)
@@ -1132,7 +1132,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         db_inst_list = cls._db_instance_get_active_by_window_joined(
             context, begin, end, project_id, host,
             columns_to_join=_expected_cols(expected_attrs),
-            use_slave=use_slave)
+            use_subordinate=use_subordinate)
         return _make_instance_list(context, cls(), db_inst_list,
                                    expected_attrs)
 
@@ -1140,7 +1140,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
     def get_active_by_window_joined(cls, context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
         """Get instances and joins active during a certain time window.
 
         :param:context: compute request context
@@ -1150,7 +1150,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         :param:host: used to filter instances on a given compute host
         :param:expected_attrs: list of related fields that can be joined
         in the database layer when querying for instances
-        :param use_slave if True, ship this query off to a DB slave
+        :param use_subordinate if True, ship this query off to a DB subordinate
         :returns: InstanceList
 
         """
@@ -1161,7 +1161,7 @@ class InstanceList(base.ObjectListBase, base.NovaObject):
         return cls._get_active_by_window_joined(context, begin, end,
                                                 project_id, host,
                                                 expected_attrs,
-                                                use_slave=use_slave)
+                                                use_subordinate=use_subordinate)
 
     @base.remotable_classmethod
     def get_by_security_group_id(cls, context, security_group_id):

--- a/jacket/objects/compute/migration.py
+++ b/jacket/objects/compute/migration.py
@@ -155,7 +155,7 @@ class Migration(base.NovaPersistentObject, base.NovaObject,
 class MigrationList(base.ObjectListBase, base.NovaObject):
     # Version 1.0: Initial version
     #              Migration <= 1.1
-    # Version 1.1: Added use_slave to get_unconfirmed_by_dest_compute
+    # Version 1.1: Added use_subordinate to get_unconfirmed_by_dest_compute
     # Version 1.2: Migration version 1.2
     # Version 1.3: Added a new function to get in progress migrations
     #              for an instance.
@@ -168,15 +168,15 @@ class MigrationList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=False):
+            context, confirm_window, dest_compute, use_subordinate=False):
         return db.migration_get_unconfirmed_by_dest_compute(
             context, confirm_window, dest_compute)
 
     @base.remotable_classmethod
     def get_unconfirmed_by_dest_compute(cls, context, confirm_window,
-                                        dest_compute, use_slave=False):
+                                        dest_compute, use_subordinate=False):
         db_migrations = cls._db_migration_get_unconfirmed_by_dest_compute(
-            context, confirm_window, dest_compute, use_slave=use_slave)
+            context, confirm_window, dest_compute, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context), objects.Migration,
                                   db_migrations)
 

--- a/jacket/objects/compute/service.py
+++ b/jacket/objects/compute/service.py
@@ -82,7 +82,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
     # Version 1.1: Added compute_node nested object
     # Version 1.2: String attributes updated to support unicode
     # Version 1.3: ComputeNode version 1.5
-    # Version 1.4: Added use_slave to get_by_compute_host
+    # Version 1.4: Added use_subordinate to get_by_compute_host
     # Version 1.5: ComputeNode version 1.6
     # Version 1.6: ComputeNode version 1.7
     # Version 1.7: ComputeNode version 1.8
@@ -236,13 +236,13 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_by_compute_host(context, host, use_slave=False):
+    def _db_service_get_by_compute_host(context, host, use_subordinate=False):
         return db.service_get_by_compute_host(context, host)
 
     @base.remotable_classmethod
-    def get_by_compute_host(cls, context, host, use_slave=False):
+    def get_by_compute_host(cls, context, host, use_subordinate=False):
         db_service = cls._db_service_get_by_compute_host(context, host,
-                                                         use_slave=use_slave)
+                                                         use_subordinate=use_subordinate)
         return cls._from_db_object(context, cls(), db_service)
 
     # NOTE(ndipanov): This is deprecated and should be removed on the next
@@ -332,11 +332,11 @@ class Service(base.NovaPersistentObject, base.NovaObject,
 
     @staticmethod
     @db.select_db_reader_mode
-    def _db_service_get_minimum_version(context, binary, use_slave=False):
+    def _db_service_get_minimum_version(context, binary, use_subordinate=False):
         return db.service_get_minimum_version(context, binary)
 
     @base.remotable_classmethod
-    def get_minimum_version(cls, context, binary, use_slave=False):
+    def get_minimum_version(cls, context, binary, use_subordinate=False):
         if not binary.startswith('nova-') and not binary.startswith('jacket-'):
             LOG.warning(_LW('get_minimum_version called with likely-incorrect '
                             'binary `%s\''), binary)
@@ -348,7 +348,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
             if cached_version:
                 return cached_version
         version = cls._db_service_get_minimum_version(context, binary,
-                                                      use_slave=use_slave)
+                                                      use_subordinate=use_subordinate)
         if version is None:
             return 0
         # NOTE(danms): Since our return value is not controlled by object

--- a/jacket/objects/compute/virtual_interface.py
+++ b/jacket/objects/compute/virtual_interface.py
@@ -96,12 +96,12 @@ class VirtualInterfaceList(base.ObjectListBase, base.NovaObject):
     @staticmethod
     @db.select_db_reader_mode
     def _db_virtual_interface_get_by_instance(context, instance_uuid,
-                                              use_slave=False):
+                                              use_subordinate=False):
         return db.virtual_interface_get_by_instance(context, instance_uuid)
 
     @base.remotable_classmethod
-    def get_by_instance_uuid(cls, context, instance_uuid, use_slave=False):
+    def get_by_instance_uuid(cls, context, instance_uuid, use_subordinate=False):
         db_vifs = cls._db_virtual_interface_get_by_instance(
-            context, instance_uuid, use_slave=use_slave)
+            context, instance_uuid, use_subordinate=use_subordinate)
         return base.obj_make_list(context, cls(context),
                                   objects.VirtualInterface, db_vifs)

--- a/jacket/tests/compute/functional/api_sample_tests/test_volumes.py
+++ b/jacket/tests/compute/functional/api_sample_tests/test_volumes.py
@@ -213,7 +213,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
     def _stub_db_bdms_get_all_by_instance(self, server_id):
 
         def fake_bdms_get_all_by_instance(context, instance_uuid,
-                                          use_slave=False):
+                                          use_subordinate=False):
             bdms = [
                 fake_block_device.FakeDbBlockDeviceDict(
                 {'id': 1, 'volume_id': 'a26887c6-c47b-4654-abb5-dfadf7d3f803',

--- a/jacket/tests/compute/unit/api/openstack/compute/test_disk_config.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_disk_config.py
@@ -65,7 +65,7 @@ class DiskConfigTestCaseV21(test.TestCase):
         self.stub_out('compute.db.instance_get', fake_instance_get)
 
         def fake_instance_get_by_uuid(context, uuid,
-                                      columns_to_join=None, use_slave=False):
+                                      columns_to_join=None, use_subordinate=False):
             for instance in FAKE_INSTANCES:
                 if uuid == instance['uuid']:
                     return instance

--- a/jacket/tests/compute/unit/api/openstack/compute/test_instance_actions.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_instance_actions.py
@@ -91,7 +91,7 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -107,7 +107,7 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
 
         def fake_instance_get_by_uuid(context, instance_id,
                                       columns_to_join=None,
-                                      use_slave=False):
+                                      use_subordinate=False):
             return fake_instance.fake_db_instance(
                 **{'name': 'fake', 'project_id': '%s_unequal' %
                        context.project_id})
@@ -143,7 +143,7 @@ class InstanceActionsTestV21(test.NoDBTestCase):
         self.fake_actions = copy.deepcopy(fake_server_actions.FAKE_ACTIONS)
         self.fake_events = copy.deepcopy(fake_server_actions.FAKE_EVENTS)
 
-        def fake_instance_get_by_uuid(context, instance_id, use_slave=False):
+        def fake_instance_get_by_uuid(context, instance_id, use_subordinate=False):
             return fake_instance.fake_instance_obj(None,
                 **{'name': 'fake', 'project_id': context.project_id})
 

--- a/jacket/tests/compute/unit/api/openstack/compute/test_security_groups.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_security_groups.py
@@ -91,7 +91,7 @@ def security_group_rule_db(rule, id=None):
 
 
 def return_server(context, server_id,
-                  columns_to_join=None, use_slave=False):
+                  columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -102,7 +102,7 @@ def return_server(context, server_id,
 
 def return_server_by_uuid(context, server_uuid,
                           columns_to_join=None,
-                          use_slave=False):
+                          use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'power_state': 0x01,
@@ -428,7 +428,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': groups}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
 
@@ -453,7 +453,7 @@ class TestSecurityGroupsV21(test.TestCase):
         expected = {'security_groups': []}
 
         def return_instance(context, server_id,
-                            columns_to_join=None, use_slave=False):
+                            columns_to_join=None, use_subordinate=False):
             self.assertEqual(server_id, FAKE_UUID1)
             return return_server_by_uuid(context, server_id)
         mock_db_get_ins.side_effect = return_instance

--- a/jacket/tests/compute/unit/api/openstack/compute/test_server_actions.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_server_actions.py
@@ -507,7 +507,7 @@ class ServerActionsControllerTestV21(test.TestCase):
 
     def test_rebuild_server_not_found(self):
         def server_not_found(self, instance_id,
-                             columns_to_join=None, use_slave=False):
+                             columns_to_join=None, use_subordinate=False):
             raise exception.InstanceNotFound(instance_id=instance_id)
         self.stub_out('compute.db.instance_get_by_uuid', server_not_found)
 
@@ -951,7 +951,7 @@ class ServerActionsControllerTestV21(test.TestCase):
                     delete_on_termination=False)]
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',
@@ -1043,7 +1043,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         image_service = glance.get_default_image_service()
 
         def fake_block_device_mapping_get_all_by_instance(context, inst_id,
-                                                          use_slave=False):
+                                                          use_subordinate=False):
             return [fake_block_device.FakeDbBlockDeviceDict(
                         {'volume_id': _fake_id('a'),
                          'source_type': 'snapshot',

--- a/jacket/tests/compute/unit/api/openstack/compute/test_server_metadata.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_server_metadata.py
@@ -94,7 +94,7 @@ def return_server(context, server_id, columns_to_join=None):
 
 
 def return_server_by_uuid(context, server_uuid,
-                          columns_to_join=None, use_slave=False):
+                          columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'id': 1,
            'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',
@@ -106,7 +106,7 @@ def return_server_by_uuid(context, server_uuid,
 
 
 def return_server_nonexistent(context, server_id,
-        columns_to_join=None, use_slave=False):
+        columns_to_join=None, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=server_id)
 
 
@@ -738,7 +738,7 @@ class BadStateServerMetaDataTestV21(test.TestCase):
                'vm_state': vm_states.BUILDING})
 
     def _return_server_in_build_by_uuid(self, context, server_uuid,
-                                        columns_to_join=None, use_slave=False):
+                                        columns_to_join=None, use_subordinate=False):
         return fake_instance.fake_db_instance(
             **{'id': 1,
                'uuid': '0cc3346e-9fef-4445-abe6-5d2b2690ec64',

--- a/jacket/tests/compute/unit/api/openstack/compute/test_server_start_stop.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_server_start_stop.py
@@ -31,7 +31,7 @@ from jacket.tests.compute.unit.api.openstack import fakes
 
 
 def fake_instance_get(context, instance_id,
-                      columns_to_join=None, use_slave=False):
+                      columns_to_join=None, use_subordinate=False):
     result = fakes.stub_instance(id=1, uuid=instance_id)
     result['created_at'] = None
     result['deleted_at'] = None

--- a/jacket/tests/compute/unit/api/openstack/compute/test_serversV21.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_serversV21.py
@@ -115,7 +115,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 

--- a/jacket/tests/compute/unit/api/openstack/compute/test_shelve.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_shelve.py
@@ -28,7 +28,7 @@ from jacket.tests.compute.unit import fake_instance
 
 
 def fake_instance_get_by_uuid(context, instance_id,
-                              columns_to_join=None, use_slave=False):
+                              columns_to_join=None, use_subordinate=False):
     return fake_instance.fake_db_instance(
         **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
 

--- a/jacket/tests/compute/unit/api/openstack/compute/test_simple_tenant_usage.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_simple_tenant_usage.py
@@ -157,11 +157,11 @@ class SimpleTenantUsageTestV21(test.TestCase):
         def fake_get_active_by_window_joined(context, begin, end=None,
                                     project_id=None, host=None,
                                     expected_attrs=None,
-                                    use_slave=False):
+                                    use_subordinate=False):
             self.assertEqual(['flavor'], expected_attrs)
             return orig_get_active_by_window_joined(context, begin, end,
                                                     project_id, host,
-                                                    expected_attrs, use_slave)
+                                                    expected_attrs, use_subordinate)
 
         with mock.patch.object(compute.InstanceList,
                                'get_active_by_window_joined',

--- a/jacket/tests/compute/unit/api/openstack/compute/test_volumes.py
+++ b/jacket/tests/compute/unit/api/openstack/compute/test_volumes.py
@@ -104,7 +104,7 @@ def fake_compute_volume_snapshot_create(self, context, volume_id,
     pass
 
 
-def fake_bdms_get_all_by_instance(context, instance_uuid, use_slave=False):
+def fake_bdms_get_all_by_instance(context, instance_uuid, use_subordinate=False):
     return [fake_block_device.FakeDbBlockDeviceDict(
             {'id': 1,
              'instance_uuid': instance_uuid,

--- a/jacket/tests/compute/unit/api/openstack/fakes.py
+++ b/jacket/tests/compute/unit/api/openstack/fakes.py
@@ -354,7 +354,7 @@ def get_fake_uuid(token=0):
 
 
 def fake_instance_get(**kwargs):
-    def _return_server(context, uuid, columns_to_join=None, use_slave=False):
+    def _return_server(context, uuid, columns_to_join=None, use_subordinate=False):
         return stub_instance(1, **kwargs)
     return _return_server
 
@@ -384,8 +384,8 @@ def fake_instance_get_all_by_filters(num_servers=5, **kwargs):
         if 'columns_to_join' in kwargs:
             kwargs.pop('columns_to_join')
 
-        if 'use_slave' in kwargs:
-            kwargs.pop('use_slave')
+        if 'use_subordinate' in kwargs:
+            kwargs.pop('use_subordinate')
 
         if 'sort_keys' in kwargs:
             kwargs.pop('sort_keys')
@@ -690,7 +690,7 @@ def stub_snapshot_get_all(self, context):
 
 
 def stub_bdm_get_all_by_instance_uuids(context, instance_uuids,
-                                       use_slave=False):
+                                       use_subordinate=False):
     i = 1
     result = []
     for instance_uuid in instance_uuids:

--- a/jacket/tests/compute/unit/compute/test_compute.py
+++ b/jacket/tests/compute/unit/compute/test_compute.py
@@ -165,7 +165,7 @@ class BaseTestCase(test.TestCase):
                     self.compute.driver, NODENAME)
         self.compute._resource_tracker_dict[NODENAME] = fake_rt
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             fake_compute_nodes = [{'local_gb': 259,
                                    'uuid': uuids.fake_compute_node,
                                    'vcpus_used': 0,
@@ -649,7 +649,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         time.time().AndReturn(20)
         time.time().AndReturn(21)
         cloud.InstanceList.get_by_host(ctxt, 'fake-mini',
-                                         use_slave=True).AndReturn([])
+                                         use_subordinate=True).AndReturn([])
         self.compute.driver.get_all_bw_counters([]).AndRaise(
             NotImplementedError)
         self.mox.ReplayAll()
@@ -678,10 +678,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  uuids.volume_instance,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     def test_poll_volume_usage_disabled(self):
@@ -700,7 +700,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.mox.StubOutWithMock(self.compute, '_get_host_volume_bdms')
         self.mox.StubOutWithMock(self.compute.driver, 'get_all_volume_usage')
         # Following methods are called.
-        self.compute._get_host_volume_bdms(ctxt, use_slave=True).AndReturn([])
+        self.compute._get_host_volume_bdms(ctxt, use_subordinate=True).AndReturn([])
         self.mox.ReplayAll()
 
         self.flags(volume_usage_poll_interval=10)
@@ -715,7 +715,7 @@ class ComputeVolumeTestCase(BaseTestCase):
                        lambda x, y: [3, 4])
         # All the mocks are called
         self.compute._get_host_volume_bdms(ctxt,
-                                           use_slave=True).AndReturn([1, 2])
+                                           use_subordinate=True).AndReturn([1, 2])
         self.compute._update_volume_usage_cache(ctxt, [3, 4])
         self.mox.ReplayAll()
         self.flags(volume_usage_poll_interval=10)
@@ -754,7 +754,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.compute.driver.block_stats(instance, 'vdb').\
             AndReturn([1, 30, 1, 20, None])
         self.compute._get_host_volume_bdms(self.context,
-                                           use_slave=True).AndReturn(
+                                           use_subordinate=True).AndReturn(
                                                host_volume_bdms)
         self.compute.driver.get_all_volume_usage(
                 self.context, host_volume_bdms).AndReturn(
@@ -6154,9 +6154,9 @@ class ComputeTestCase(BaseTestCase):
         self.compute._shutdown_instance(ctxt, inst1, bdms, notify=False).\
                                         AndRaise(test.TestingException)
         cloud.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst1.uuid, use_slave=True).AndReturn(bdms)
+                inst1.uuid, use_subordinate=True).AndReturn(bdms)
         cloud.BlockDeviceMappingList.get_by_instance_uuid(ctxt,
-                inst2.uuid, use_slave=True).AndReturn(bdms)
+                inst2.uuid, use_subordinate=True).AndReturn(bdms)
         self.compute._shutdown_instance(ctxt, inst2, bdms, notify=False).\
                                         AndReturn(None)
 
@@ -6263,13 +6263,13 @@ class ComputeTestCase(BaseTestCase):
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -6279,7 +6279,7 @@ class ComputeTestCase(BaseTestCase):
             return instance_map[instance_uuid]
 
         # NOTE(comstud): Override the stub in setUp()
-        def fake_get_instance_nw_info(context, instance, use_slave=False):
+        def fake_get_instance_nw_info(context, instance, use_subordinate=False):
             # Note that this exception gets caught in cloud/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -6377,7 +6377,7 @@ class ComputeTestCase(BaseTestCase):
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -6427,7 +6427,7 @@ class ComputeTestCase(BaseTestCase):
                        task_states.REBOOTING, task_states.REBOOT_STARTED,
                        task_states.REBOOT_PENDING]}
         get.assert_called_once_with(ctxt, filters,
-                                    expected_attrs=[], use_slave=True)
+                                    expected_attrs=[], use_subordinate=True)
 
     def test_poll_unconfirmed_resizes(self):
         instances = [
@@ -6479,7 +6479,7 @@ class ComputeTestCase(BaseTestCase):
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for non-existing instance
@@ -6491,7 +6491,7 @@ class ComputeTestCase(BaseTestCase):
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -6992,7 +6992,7 @@ class ComputeTestCase(BaseTestCase):
         cloud.InstanceList.get_by_filters(
             ctxt, mox.IgnoreArg(),
             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-            use_slave=True
+            use_subordinate=True
             ).AndReturn(instances)
 
         # The first instance delete fails.
@@ -7033,12 +7033,12 @@ class ComputeTestCase(BaseTestCase):
             hardware.InstanceInfo(state=power_state.RUNNING))
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.RUNNING,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.compute.driver.get_info(mox.IgnoreArg()).AndReturn(
             hardware.InstanceInfo(state=power_state.SHUTDOWN))
         self.compute._sync_instance_power_state(ctxt, mox.IgnoreArg(),
                                                 power_state.SHUTDOWN,
-                                                use_slave=True)
+                                                use_subordinate=True)
         self.mox.ReplayAll()
         self.compute._sync_power_states(ctxt)
 
@@ -10994,7 +10994,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-                aggregate=jsonutils.to_primitive(self.aggr), slave_info=None)
+                aggregate=jsonutils.to_primitive(self.aggr), subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -11008,36 +11008,36 @@ class ComputeAggrTestCase(BaseTestCase):
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="host",
-                slave_info=None)
+                subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-                slave_info="SLAVE_INFO",
+                subordinate_info="SLAVE_INFO",
                 aggregate=jsonutils.to_primitive(self.aggr))
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate['id'], self.aggr['id'])
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stubs.Set(self.compute.driver, "remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
                 aggregate=jsonutils.to_primitive(self.aggr), host="the_host",
-                slave_info="SLAVE_INFO")
+                subordinate_info="SLAVE_INFO")
 
 
 class ComputePolicyTestCase(BaseTestCase):

--- a/jacket/tests/compute/unit/compute/test_compute_api.py
+++ b/jacket/tests/compute/unit/compute/test_compute_api.py
@@ -2277,7 +2277,7 @@ class _ComputeAPIUnitTestMixIn(object):
         quiesced = [False, False]
         quiesce_expected = not quiesce_fails and vm_state == vm_states.ACTIVE
 
-        def fake_get_all_by_instance(context, instance, use_slave=False):
+        def fake_get_all_by_instance(context, instance, use_subordinate=False):
             return copy.deepcopy(instance_bdms)
 
         def fake_image_create(context, image_meta, data=None):

--- a/jacket/tests/compute/unit/compute/test_compute_mgr.py
+++ b/jacket/tests/compute/unit/compute/test_compute_mgr.py
@@ -204,7 +204,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         get_avail_nodes.return_value = avail_nodes
         get_rt.side_effect = _get_rt_side_effect
         self.compute.update_available_resource(ctxt)
-        get_db_nodes.assert_called_once_with(ctxt, use_slave=True)
+        get_db_nodes.assert_called_once_with(ctxt, use_subordinate=True)
         self.assertEqual(sorted([mock.call(node) for node in avail_nodes]),
                          sorted(get_rt.call_args_list))
         for rt in rts:
@@ -1379,7 +1379,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._sync_power_states(mock.sentinel.context)
             mock_get.assert_called_with(mock.sentinel.context,
                                         self.compute.host, expected_attrs=[],
-                                        use_slave=True)
+                                        use_subordinate=True)
             mock_spawn.assert_called_once_with(mock.ANY, instance)
 
     def _get_sync_instance(self, power_state, vm_state, task_state=None,
@@ -1398,7 +1398,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_match(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
@@ -1406,7 +1406,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_sync_instance_power_state_running_stopped(self):
         instance = self._get_sync_instance(power_state.RUNNING,
                                            vm_states.ACTIVE)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.ReplayAll()
         self.compute._sync_instance_power_state(self.context, instance,
@@ -1417,7 +1417,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                            stop=True, force=False, shutdown_terminate=False):
         instance = self._get_sync_instance(
             power_state, vm_state, shutdown_terminate=shutdown_terminate)
-        instance.refresh(use_slave=False)
+        instance.refresh(use_subordinate=False)
         instance.save()
         self.mox.StubOutWithMock(self.compute.compute_api, 'stop')
         self.mox.StubOutWithMock(self.compute.compute_api, 'delete')
@@ -1489,7 +1489,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     def test_run_pending_deletes(self):
         self.flags(instance_delete_interval=10)
@@ -1519,7 +1519,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
              'cleaned': False},
             expected_attrs=['info_cache', 'security_groups',
                             'system_metadata'],
-            use_slave=True).AndReturn([a, b, c])
+            use_subordinate=True).AndReturn([a, b, c])
 
         self.mox.StubOutWithMock(self.compute.driver, 'delete_instance_files')
         self.compute.driver.delete_instance_files(
@@ -2867,7 +2867,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._poll_bandwidth_usage(self.context)
             get_by_uuid_mac.assert_called_once_with(self.context,
                     uuids.instance, 'fake-mac',
-                    start_period=0, use_slave=True)
+                    start_period=0, use_subordinate=True)
             # NOTE(sdague): bw_usage_update happens at some time in
             # the future, so what last_refreshed is irrelevant.
             bw_usage_update.assert_called_once_with(self.context,
@@ -2940,7 +2940,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.compute._sync_scheduler_instance_info(self.context)
         mock_get_by_host.assert_called_once_with(
                 fake_elevated, self.compute.host, expected_attrs=[],
-                use_slave=True)
+                use_subordinate=True)
         mock_sync.assert_called_once_with(fake_elevated, self.compute.host,
                                           exp_uuids)
 

--- a/jacket/tests/compute/unit/compute/test_compute_xen.py
+++ b/jacket/tests/compute/unit/compute/test_compute_xen.py
@@ -55,7 +55,7 @@ class ComputeXenTestCase(stubs.XenAPITestBaseNoDB):
 
         compute.InstanceList.get_by_host(ctxt,
                 self.compute.host, expected_attrs=[],
-                use_slave=True).AndReturn(instance_list)
+                use_subordinate=True).AndReturn(instance_list)
         self.compute.driver.get_num_instances().AndReturn(1)
         vm_utils.lookup(self.compute.driver._session, instance['name'],
                 False).AndReturn(None)

--- a/jacket/tests/compute/unit/compute/test_multiple_nodes.py
+++ b/jacket/tests/compute/unit/compute/test_multiple_nodes.py
@@ -71,7 +71,7 @@ class MultiNodeComputeTestCase(BaseTestCase):
         self.conductor = self.start_service('conductor',
                                             manager=CONF.conductor.manager)
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             fake_compute_nodes = [{'local_gb': 259,
                                    'uuid': uuidsentinel.fake_compute,
                                    'vcpus_used': 0,
@@ -142,7 +142,7 @@ class MultiNodeComputeTestCase(BaseTestCase):
                 context=ctx, hypervisor_hostname='B', id=3),
             ]
 
-        def fake_get_compute_nodes_in_db(context, use_slave=False):
+        def fake_get_compute_nodes_in_db(context, use_subordinate=False):
             return fake_compute_nodes
 
         def fake_compute_node_delete(context, compute_node_id):

--- a/jacket/tests/compute/unit/compute/test_rpcapi.py
+++ b/jacket/tests/compute/unit/compute/test_rpcapi.py
@@ -152,7 +152,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_add_aggregate_host(self):
         self._test_compute_api('add_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_add_fixed_ip_to_instance(self):
         self._test_compute_api('add_fixed_ip_to_instance', 'cast',
@@ -402,7 +402,7 @@ class ComputeRpcAPITestCase(test.NoDBTestCase):
     def test_remove_aggregate_host(self):
         self._test_compute_api('remove_aggregate_host', 'cast',
                 aggregate={'id': 'fake_id'}, host_param='host', host='host',
-                slave_info={})
+                subordinate_info={})
 
     def test_remove_fixed_ip_from_instance(self):
         self._test_compute_api('remove_fixed_ip_from_instance', 'cast',

--- a/jacket/tests/compute/unit/db/test_db_api.py
+++ b/jacket/tests/compute/unit/db/test_db_api.py
@@ -189,7 +189,7 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_sync(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
@@ -206,21 +206,21 @@ class DecoratorTestCase(test.TestCase):
     def test_select_db_reader_mode_select_async(self, mock_clone, mock_using):
 
         @db.select_db_reader_mode
-        def func(self, context, value, use_slave=False):
+        def func(self, context, value, use_subordinate=False):
             pass
 
         mock_clone.return_value = enginefacade._TransactionContextManager(
             mode=enginefacade._ASYNC_READER)
         ctxt = context.get_admin_context()
         value = 'some_value'
-        func(self, ctxt, value, use_slave=True)
+        func(self, ctxt, value, use_subordinate=True)
 
         mock_clone.assert_called_once_with(mode=enginefacade._ASYNC_READER)
         mock_using.assert_called_once_with(ctxt)
 
     @mock.patch.object(enginefacade._TransactionContextManager, 'using')
     @mock.patch.object(enginefacade._TransactionContextManager, '_clone')
-    def test_select_db_reader_mode_no_use_slave_select_sync(self, mock_clone,
+    def test_select_db_reader_mode_no_use_subordinate_select_sync(self, mock_clone,
                                                             mock_using):
 
         @db.select_db_reader_mode
@@ -1069,7 +1069,7 @@ class SqlAlchemyDbApiNoDbTestCase(test.NoDBTestCase):
 
         sqlalchemy_api.get_engine()
         mock_create_facade.assert_called_once_with()
-        mock_facade.get_engine.assert_called_once_with(use_slave=False)
+        mock_facade.get_engine.assert_called_once_with(use_subordinate=False)
 
     def test_get_db_conf_with_connection(self):
         mock_conf_group = mock.MagicMock()

--- a/jacket/tests/compute/unit/network/test_api.py
+++ b/jacket/tests/compute/unit/network/test_api.py
@@ -195,7 +195,7 @@ class ApiTestCase(test.TestCase):
 
         def fake_instance_get_by_uuid(context, instance_uuid,
                                       columns_to_join=None,
-                                      use_slave=None):
+                                      use_subordinate=None):
             if instance_uuid == orig_instance_uuid:
                 self.assertIn('extra.flavor', columns_to_join)
             return fake_instance.fake_db_instance(uuid=instance_uuid)

--- a/jacket/tests/compute/unit/network/test_linux_net.py
+++ b/jacket/tests/compute/unit/network/test_linux_net.py
@@ -389,7 +389,7 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
         self.context = context.RequestContext('testuser', 'testproject',
                                               is_admin=True)
 
-        def get_vifs(_context, instance_uuid, use_slave):
+        def get_vifs(_context, instance_uuid, use_subordinate):
             return [vif for vif in vifs if vif['instance_uuid'] ==
                         instance_uuid]
 

--- a/jacket/tests/compute/unit/objects/test_instance.py
+++ b/jacket/tests/compute/unit/objects/test_instance.py
@@ -284,7 +284,7 @@ class _TestInstanceObject(object):
         self.mox.StubOutWithMock(compute.Instance, 'get_by_uuid')
         compute.Instance.get_by_uuid(self.context, uuid=inst.uuid,
                                      expected_attrs=['metadata'],
-                                     use_slave=False
+                                     use_subordinate=False
                                      ).AndReturn(inst_copy)
         self.mox.ReplayAll()
         self.assertRaises(exception.OrphanedObjectError, inst.refresh)
@@ -419,7 +419,7 @@ class _TestInstanceObject(object):
         self.mox.ReplayAll()
 
         inst = compute.Instance.get_by_uuid(self.context, old_ref['uuid'],
-                                            use_slave=False)
+                                            use_subordinate=False)
         self.assertEqual('hello', inst.display_name)
         inst.display_name = 'goodbye'
         inst.save()
@@ -1390,7 +1390,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         inst_list = compute.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1407,7 +1407,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         inst_list = compute.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, expected_attrs=['metadata'],
-            use_slave=False, sort_keys=['uuid'], sort_dirs=['asc'])
+            use_subordinate=False, sort_keys=['uuid'], sort_dirs=['asc'])
 
         for i in range(0, len(fakes)):
             self.assertIsInstance(inst_list.objects[i], instance.Instance)
@@ -1422,7 +1422,7 @@ class _TestInstanceListObject(object):
         # Single sort key/direction is set, call non-sorted DB function
         compute.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, sort_key='key', sort_dir='dir',
-            limit=100, marker='uuid', use_slave=True)
+            limit=100, marker='uuid', use_subordinate=True)
         mock_get_by_filters.assert_called_once_with(
             self.context, {'foo': 'bar'}, 'key', 'dir', limit=100,
             marker='uuid', columns_to_join=None)
@@ -1437,7 +1437,7 @@ class _TestInstanceListObject(object):
         # Multiple sort keys/directions are set, call sorted DB function
         compute.InstanceList.get_by_filters(
             self.context, {'foo': 'bar'}, limit=100, marker='uuid',
-            use_slave=True, sort_keys=['key1', 'key2'],
+            use_subordinate=True, sort_keys=['key1', 'key2'],
             sort_dirs=['dir1', 'dir2'])
         mock_get_by_filters_sort.assert_called_once_with(
             self.context, {'foo': 'bar'}, limit=100,
@@ -1459,7 +1459,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         inst_list = compute.InstanceList.get_by_filters(
             self.context, {'deleted': True, 'cleaned': False}, 'uuid', 'asc',
-            expected_attrs=['metadata'], use_slave=False)
+            expected_attrs=['metadata'], use_subordinate=False)
 
         self.assertEqual(1, len(inst_list))
         self.assertIsInstance(inst_list.objects[0], instance.Instance)
@@ -1578,7 +1578,7 @@ class _TestInstanceListObject(object):
         self.mox.ReplayAll()
         instances = compute.InstanceList.get_by_host(self.context, 'host',
                                                      expected_attrs=['fault'],
-                                                     use_slave=False)
+                                                     use_subordinate=False)
         self.assertEqual(2, len(instances))
         self.assertEqual(fake_faults['fake-uuid'][0],
                          dict(instances[0].fault))

--- a/jacket/tests/compute/unit/objects/test_migration.py
+++ b/jacket/tests/compute/unit/objects/test_migration.py
@@ -184,7 +184,7 @@ class _TestMigrationObject(object):
         self.mox.ReplayAll()
         migrations = (
             migration.MigrationList.get_unconfirmed_by_dest_compute(
-                ctxt, 'window', 'foo', use_slave=False))
+                ctxt, 'window', 'foo', use_subordinate=False))
         self.assertEqual(2, len(migrations))
         for index, db_migration in enumerate(db_migrations):
             self.compare_obj(migrations[index], db_migration)

--- a/jacket/tests/compute/unit/virt/libvirt/test_driver.py
+++ b/jacket/tests/compute/unit/virt/libvirt/test_driver.py
@@ -10851,7 +10851,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             self.assertEqual(2, mock_info.call_count)
 
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains")
@@ -10925,7 +10925,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
         mock_list.assert_called_once_with()
         self.assertEqual(2, get_disk_info.call_count)
         filters = {'uuid': instance_uuids}
-        mock_get.assert_called_once_with(mock.ANY, filters, use_slave=True)
+        mock_get.assert_called_once_with(mock.ANY, filters, use_subordinate=True)
         mock_bdms.assert_called_with(mock.ANY, instance_uuids)
 
     @mock.patch.object(host.Host, "list_instance_domains",

--- a/jacket/tests/compute/unit/virt/xenapi/client/test_session.py
+++ b/jacket/tests/compute/unit/virt/xenapi/client/test_session.py
@@ -74,10 +74,10 @@ class SessionTestCase(stubs.XenAPITestBaseNoDB):
         # First login fails, second login in except block succeeds,
         # third login for the pool succeeds
         sess.login_with_password.side_effect = [
-                XenAPI.Failure(['HOST_IS_SLAVE', 'master']), None, None]
+                XenAPI.Failure(['HOST_IS_SLAVE', 'main']), None, None]
         mock_version.return_value = ('version', 'brand')
 
-        session.XenAPISession('http://slave', 'username', 'password')
+        session.XenAPISession('http://subordinate', 'username', 'password')
         self.assertEqual(3, sess.login_with_password.call_count)
         self.assertEqual(3, mock_timeout.call_count)
 

--- a/jacket/tests/compute/unit/virt/xenapi/test_xenapi.py
+++ b/jacket/tests/compute/unit/virt/xenapi/test_xenapi.py
@@ -1500,7 +1500,7 @@ iface eth0 inet6 static
         self.stub_out("compute.compute.aggregate_get_by_host",
                        fake_aggregate_get_by_host)
 
-        self.stubs.Set(self.conn._session, "is_slave", True)
+        self.stubs.Set(self.conn._session, "is_subordinate", True)
 
         self.assertRaises(test.TestingException,
                 self.conn._session._get_host_uuid)
@@ -1514,7 +1514,7 @@ iface eth0 inet6 static
         self.stub_out('compute.compute.aggregate_get_by_host',
                       fake_aggregate_get)
 
-        self.stubs.Set(self.conn._session, "is_slave", True)
+        self.stubs.Set(self.conn._session, "is_subordinate", True)
 
         self.assertEqual('this_should_be_metadata',
                          self.conn._session._get_host_uuid())
@@ -2970,7 +2970,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.aggr = compute.Aggregate(context=self.context, id=1,
                                       **values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -2980,18 +2980,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
 
         calls = []
 
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_add_to_aggregate)
         self.stubs.Set(self.conn._pool,
                        "add_to_aggregate",
                        pool_add_to_aggregate)
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_add_to_aggregate, calls)
 
@@ -3000,18 +3000,18 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         calls = []
 
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
             calls.append(pool_remove_from_aggregate)
         self.stubs.Set(self.conn._pool,
                        "remove_from_aggregate",
                        pool_remove_from_aggregate)
 
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertIn(pool_remove_from_aggregate, calls)
 
@@ -3027,11 +3027,11 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result['metadetails']))
 
-    def test_join_slave(self):
-        # Ensure join_slave gets called when the request gets to master.
-        def fake_join_slave(id, compute_uuid, host, url, user, password):
-            fake_join_slave.called = True
-        self.stubs.Set(self.conn._pool, "_join_slave", fake_join_slave)
+    def test_join_subordinate(self):
+        # Ensure join_subordinate gets called when the request gets to main.
+        def fake_join_subordinate(id, compute_uuid, host, url, user, password):
+            fake_join_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_join_subordinate", fake_join_subordinate)
 
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
@@ -3041,7 +3041,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(fake_join_slave.called)
+        self.assertTrue(fake_join_subordinate.called)
 
     def test_add_to_aggregate_first_host(self):
         def fake_pool_set_name_label(self, session, pool_ref, name):
@@ -3081,19 +3081,19 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    def test_remove_slave(self):
-        # Ensure eject slave gets called.
-        def fake_eject_slave(id, compute_uuid, host_uuid):
-            fake_eject_slave.called = True
-        self.stubs.Set(self.conn._pool, "_eject_slave", fake_eject_slave)
+    def test_remove_subordinate(self):
+        # Ensure eject subordinate gets called.
+        def fake_eject_subordinate(id, compute_uuid, host_uuid):
+            fake_eject_subordinate.called = True
+        self.stubs.Set(self.conn._pool, "_eject_subordinate", fake_eject_subordinate)
 
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(fake_eject_slave.called)
+        self.assertTrue(fake_eject_subordinate.called)
 
-    def test_remove_master_solo(self):
+    def test_remove_main_solo(self):
         # Ensure metadata are cleared after removal.
         def fake_clear_pool(id):
             fake_clear_pool.called = True
@@ -3108,8 +3108,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result['metadetails']))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3219,7 +3219,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=self.aggr,
-                          slave_info=None)
+                          subordinate_info=None)
         self.assertEqual(self.aggr.metadata[pool_states.KEY],
                 pool_states.ERROR)
         self.assertEqual(self.aggr.hosts, ['fake_host'])
@@ -3230,16 +3230,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, aggregate_id, host_param,
-                              host, slave_info):
+                              host, subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, aggregate_id,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3254,10 +3254,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3271,33 +3271,33 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: '',
             pool_states.KEY: ''
             }
         }
     fake_aggregate = compute.Aggregate(**fake_aggregate)
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
+            (subordinate.compute_rpcapi.add_aggregate_host,
             "CONTEXT", jsonutils.to_primitive(self.fake_aggregate),
-            "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-            "CONTEXT", 98, "slave", "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+            "CONTEXT", 98, "subordinate", "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):

--- a/jacket/tests/storage/unit/api/test_xmlutil.py
+++ b/jacket/tests/storage/unit/api/test_xmlutil.py
@@ -364,15 +364,15 @@ class TemplateElementTest(test.TestCase):
                      attr2=xmlutil.ConstantSelector(2),
                      attr3=xmlutil.ConstantSelector(3))
 
-        # Create a master template element
-        master_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
+        # Create a main template element
+        main_elem = xmlutil.TemplateElement('test', attr1=attrs['attr1'])
 
-        # Create a couple of slave template element
-        slave_elems = [xmlutil.TemplateElement('test', attr2=attrs['attr2']),
+        # Create a couple of subordinate template element
+        subordinate_elems = [xmlutil.TemplateElement('test', attr2=attrs['attr2']),
                        xmlutil.TemplateElement('test', attr3=attrs['attr3']), ]
 
         # Try the render
-        elem = master_elem._render(None, None, slave_elems, None)
+        elem = main_elem._render(None, None, subordinate_elems, None)
 
         # Verify the particulars of the render
         self.assertEqual('test', elem.tag)
@@ -384,7 +384,7 @@ class TemplateElementTest(test.TestCase):
         parent = etree.Element('parent')
 
         # Try the render again...
-        elem = master_elem._render(parent, None, slave_elems, dict(a='foo'))
+        elem = main_elem._render(parent, None, subordinate_elems, dict(a='foo'))
 
         # Verify the particulars of the render
         self.assertEqual(1, len(parent))
@@ -495,46 +495,46 @@ class TemplateTest(test.TestCase):
         self.assertEqual(1, len(nsmap))
         self.assertEqual('foo', nsmap['a'])
 
-    def test_master_attach(self):
-        # Set up a master template
+    def test_main_attach(self):
+        # Set up a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1)
+        tmpl = xmlutil.MainTemplate(elem, 1)
 
-        # Make sure it has a root but no slaves
+        # Make sure it has a root but no subordinates
         self.assertEqual(elem, tmpl.root)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
-        # Try to attach an invalid slave
+        # Try to attach an invalid subordinate
         bad_elem = xmlutil.TemplateElement('test2')
         self.assertRaises(ValueError, tmpl.attach, bad_elem)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
-        # Try to attach an invalid and a valid slave
+        # Try to attach an invalid and a valid subordinate
         good_elem = xmlutil.TemplateElement('test')
         self.assertRaises(ValueError, tmpl.attach, good_elem, bad_elem)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
         # Try to attach an inapplicable template
         class InapplicableTemplate(xmlutil.Template):
-            def apply(self, master):
+            def apply(self, main):
                 return False
         inapp_tmpl = InapplicableTemplate(good_elem)
         tmpl.attach(inapp_tmpl)
-        self.assertEqual(0, len(tmpl.slaves))
+        self.assertEqual(0, len(tmpl.subordinates))
 
         # Now try attaching an applicable template
         tmpl.attach(good_elem)
-        self.assertEqual(1, len(tmpl.slaves))
-        self.assertEqual(good_elem, tmpl.slaves[0].root)
+        self.assertEqual(1, len(tmpl.subordinates))
+        self.assertEqual(good_elem, tmpl.subordinates[0].root)
 
-    def test_master_copy(self):
-        # Construct a master template
+    def test_main_copy(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        tmpl = xmlutil.MasterTemplate(elem, 1, nsmap=dict(a='foo'))
+        tmpl = xmlutil.MainTemplate(elem, 1, nsmap=dict(a='foo'))
 
-        # Give it a slave
-        slave = xmlutil.TemplateElement('test')
-        tmpl.attach(slave)
+        # Give it a subordinate
+        subordinate = xmlutil.TemplateElement('test')
+        tmpl.attach(subordinate)
 
         # Construct a copy
         copy = tmpl.copy()
@@ -544,42 +544,42 @@ class TemplateTest(test.TestCase):
         self.assertEqual(tmpl.root, copy.root)
         self.assertEqual(tmpl.version, copy.version)
         self.assertEqual(id(tmpl.nsmap), id(copy.nsmap))
-        self.assertNotEqual(id(tmpl.slaves), id(copy.slaves))
-        self.assertEqual(len(tmpl.slaves), len(copy.slaves))
-        self.assertEqual(tmpl.slaves[0], copy.slaves[0])
+        self.assertNotEqual(id(tmpl.subordinates), id(copy.subordinates))
+        self.assertEqual(len(tmpl.subordinates), len(copy.subordinates))
+        self.assertEqual(tmpl.subordinates[0], copy.subordinates[0])
 
-    def test_slave_apply(self):
-        # Construct a master template
+    def test_subordinate_apply(self):
+        # Construct a main template
         elem = xmlutil.TemplateElement('test')
-        master = xmlutil.MasterTemplate(elem, 3)
+        main = xmlutil.MainTemplate(elem, 3)
 
-        # Construct a slave template with applicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 2)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with applicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 2)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with equal minimum version
-        slave = xmlutil.SlaveTemplate(elem, 3)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with equal minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 3)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with inapplicable minimum version
-        slave = xmlutil.SlaveTemplate(elem, 4)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with inapplicable minimum version
+        subordinate = xmlutil.SubordinateTemplate(elem, 4)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with applicable version range
-        slave = xmlutil.SlaveTemplate(elem, 2, 4)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with applicable version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 2, 4)
+        self.assertTrue(subordinate.apply(main))
 
-        # Construct a slave template with low version range
-        slave = xmlutil.SlaveTemplate(elem, 1, 2)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with low version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 1, 2)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with high version range
-        slave = xmlutil.SlaveTemplate(elem, 4, 5)
-        self.assertFalse(slave.apply(master))
+        # Construct a subordinate template with high version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 4, 5)
+        self.assertFalse(subordinate.apply(main))
 
-        # Construct a slave template with matching version range
-        slave = xmlutil.SlaveTemplate(elem, 3, 3)
-        self.assertTrue(slave.apply(master))
+        # Construct a subordinate template with matching version range
+        subordinate = xmlutil.SubordinateTemplate(elem, 3, 3)
+        self.assertTrue(subordinate.apply(main))
 
     def test__serialize(self):
         # Our test object to serialize
@@ -591,7 +591,7 @@ class TemplateTest(test.TestCase):
                                   'd': 4, },
                         'image': {'name': 'image_foobar', 'id': 42, }, }, }
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test',
                                        name='name')
         value = xmlutil.SubTemplateElement(root, 'value', selector='values')
@@ -599,22 +599,22 @@ class TemplateTest(test.TestCase):
         attrs = xmlutil.SubTemplateElement(root, 'attrs', selector='attrs')
         xmlutil.SubTemplateElement(attrs, 'attr', selector=xmlutil.get_items,
                                    key=0, value=1)
-        master = xmlutil.MasterTemplate(root, 1, nsmap=dict(f='foo'))
+        main = xmlutil.MainTemplate(root, 1, nsmap=dict(f='foo'))
 
-        # Set up our slave template
-        root_slave = xmlutil.TemplateElement('test', selector='test')
-        image = xmlutil.SubTemplateElement(root_slave, 'image',
+        # Set up our subordinate template
+        root_subordinate = xmlutil.TemplateElement('test', selector='test')
+        image = xmlutil.SubTemplateElement(root_subordinate, 'image',
                                            selector='image', id='id')
         image.text = xmlutil.Selector('name')
-        slave = xmlutil.SlaveTemplate(root_slave, 1, nsmap=dict(b='bar'))
+        subordinate = xmlutil.SubordinateTemplate(root_subordinate, 1, nsmap=dict(b='bar'))
 
-        # Attach the slave to the master...
-        master.attach(slave)
+        # Attach the subordinate to the main...
+        main.attach(subordinate)
 
         # Try serializing our object
-        siblings = master._siblings()
-        nsmap = master._nsmap()
-        result = master._serialize(None, obj, siblings, nsmap)
+        siblings = main._siblings()
+        nsmap = main._nsmap()
+        result = main._serialize(None, obj, siblings, nsmap)
 
         # Now we get to manually walk the element tree...
         self.assertEqual('test', result.tag)
@@ -644,7 +644,7 @@ class TemplateTest(test.TestCase):
                         'scope0:scope1:scope2:key3': 'Value3'
                         }}
 
-        # Set up our master template
+        # Set up our main template
         root = xmlutil.TemplateElement('test', selector='test')
         key1 = xmlutil.SubTemplateElement(root, 'scope0:key1',
                                           selector='scope0:key1')
@@ -655,7 +655,7 @@ class TemplateTest(test.TestCase):
         key3 = xmlutil.SubTemplateElement(root, 'scope0:scope1:scope2:key3',
                                           selector='scope0:scope1:scope2:key3')
         key3.text = xmlutil.Selector()
-        serializer = xmlutil.MasterTemplate(root, 1)
+        serializer = xmlutil.MainTemplate(root, 1)
         expected_xml = (b"<?xmlversion='1.0'encoding='UTF-8'?><test>"
                         b"<scope0><key1>Value1</key1><scope1>"
                         b"<key2>Value2</key2><scope2><key3>Value3</key3>"
@@ -665,60 +665,60 @@ class TemplateTest(test.TestCase):
         self.assertEqual(expected_xml, result)
 
 
-class MasterTemplateBuilder(xmlutil.TemplateBuilder):
+class MainTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.MasterTemplate(elem, 1)
+        return xmlutil.MainTemplate(elem, 1)
 
 
-class SlaveTemplateBuilder(xmlutil.TemplateBuilder):
+class SubordinateTemplateBuilder(xmlutil.TemplateBuilder):
     def construct(self):
         elem = xmlutil.TemplateElement('test')
-        return xmlutil.SlaveTemplate(elem, 1)
+        return xmlutil.SubordinateTemplate(elem, 1)
 
 
 class TemplateBuilderTest(test.TestCase):
-    def test_master_template_builder(self):
+    def test_main_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNone(MainTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = MasterTemplateBuilder()
+        tmpl1 = MainTemplateBuilder()
 
         # Make sure that there is a template cached...
-        self.assertIsNotNone(MasterTemplateBuilder._tmpl)
+        self.assertIsNotNone(MainTemplateBuilder._tmpl)
 
         # Make sure it wasn't what was returned...
-        self.assertNotEqual(MasterTemplateBuilder._tmpl, tmpl1)
+        self.assertNotEqual(MainTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        cached = MasterTemplateBuilder._tmpl
-        tmpl2 = MasterTemplateBuilder()
-        self.assertEqual(MasterTemplateBuilder._tmpl, cached)
+        cached = MainTemplateBuilder._tmpl
+        tmpl2 = MainTemplateBuilder()
+        self.assertEqual(MainTemplateBuilder._tmpl, cached)
 
         # Make sure we're always getting fresh copies
         self.assertNotEqual(tmpl1, tmpl2)
 
         # Make sure we can override the copying behavior
-        tmpl3 = MasterTemplateBuilder(False)
-        self.assertEqual(MasterTemplateBuilder._tmpl, tmpl3)
+        tmpl3 = MainTemplateBuilder(False)
+        self.assertEqual(MainTemplateBuilder._tmpl, tmpl3)
 
-    def test_slave_template_builder(self):
+    def test_subordinate_template_builder(self):
         # Make sure the template hasn't been built yet
-        self.assertIsNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNone(SubordinateTemplateBuilder._tmpl)
 
         # Now, construct the template
-        tmpl1 = SlaveTemplateBuilder()
+        tmpl1 = SubordinateTemplateBuilder()
 
         # Make sure there is a template cached...
-        self.assertIsNotNone(SlaveTemplateBuilder._tmpl)
+        self.assertIsNotNone(SubordinateTemplateBuilder._tmpl)
 
         # Make sure it was what was returned...
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure it doesn't get rebuilt
-        tmpl2 = SlaveTemplateBuilder()
-        self.assertEqual(SlaveTemplateBuilder._tmpl, tmpl1)
+        tmpl2 = SubordinateTemplateBuilder()
+        self.assertEqual(SubordinateTemplateBuilder._tmpl, tmpl1)
 
         # Make sure we're always getting the cached copy
         self.assertEqual(tmpl1, tmpl2)
@@ -729,6 +729,6 @@ class MiscellaneousXMLUtilTests(test.TestCase):
         expected_xml = (b"<?xml version='1.0' encoding='UTF-8'?>\n"
                         b'<wrapper><a>foo</a></wrapper>')
         root = xmlutil.make_flat_dict('wrapper')
-        tmpl = xmlutil.MasterTemplate(root, 1)
+        tmpl = xmlutil.MainTemplate(root, 1)
         result = tmpl.serialize(dict(wrapper=dict(a='foo')))
         self.assertEqual(expected_xml, result)

--- a/jacket/tests/storage/unit/test_storwize_svc.py
+++ b/jacket/tests/storage/unit/test_storwize_svc.py
@@ -3260,29 +3260,29 @@ class StorwizeSVCCommonDriverTestCase(test.TestCase):
 
     def test_storwize_svc_delete_volume_snapshots(self):
         # Create a volume with two snapshots
-        master = self._create_volume()
+        main = self._create_volume()
 
         # Fail creating a snapshot - will force delete the snapshot
         if self.USESIM and False:
-            snap = self._generate_vol_info(master['name'], master['id'])
+            snap = self._generate_vol_info(main['name'], main['id'])
             self.sim.error_injection('startfcmap', 'bad_id')
             self.assertRaises(exception.VolumeBackendAPIException,
                               self.driver.create_snapshot, snap)
             self._assert_vol_exists(snap['name'], False)
 
         # Delete a snapshot
-        snap = self._generate_vol_info(master['name'], master['id'])
+        snap = self._generate_vol_info(main['name'], main['id'])
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
         self.driver.delete_snapshot(snap)
         self._assert_vol_exists(snap['name'], False)
 
         # Delete a volume with snapshots (regular)
-        snap = self._generate_vol_info(master['name'], master['id'])
+        snap = self._generate_vol_info(main['name'], main['id'])
         self.driver.create_snapshot(snap)
         self._assert_vol_exists(snap['name'], True)
-        self.driver.delete_volume(master)
-        self._assert_vol_exists(master['name'], False)
+        self.driver.delete_volume(main)
+        self._assert_vol_exists(main['name'], False)
 
         # Fail create volume from snapshot - will force delete the volume
         if self.USESIM:

--- a/jacket/tests/storage/unit/volume/drivers/test_hgst.py
+++ b/jacket/tests/storage/unit/volume/drivers/test_hgst.py
@@ -747,7 +747,7 @@ IP_OUTPUT = """
        valid_lft forever preferred_lft forever
     inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
-2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master
+2: em1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq main
     link/ether 00:25:90:d9:18:08 brd ff:ff:ff:ff:ff:ff
     inet6 fe80::225:90ff:fed9:1808/64 scope link
        valid_lft forever preferred_lft forever
@@ -798,7 +798,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 4800,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 98213822464,
       "totalUsedBytes": 3266781184,
@@ -818,7 +818,7 @@ HGST_HOST_STORAGE = """
         "ipDataProviderLoaded": true,
         "ibDataProviderLoaded": false,
         "driverUptimeSecs": 0,
-        "rVersion": "20368.d55ec22.master"
+        "rVersion": "20368.d55ec22.main"
       },
       "totalCapacityBytes": 0,
       "totalUsedBytes": 0,

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -33,12 +33,12 @@ Run like:
     MYSQL:
 
     ./tools/db/schema_diff.py mysql+pymysql://root@localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
     POSTGRESQL:
 
     ./tools/db/schema_diff.py postgresql://localhost \
-                              master:latest my_branch:82
+                              main:latest my_branch:82
 
 """
 
@@ -229,12 +229,12 @@ def parse_options():
     try:
         orig_branch, orig_version = sys.argv[2].split(':')
     except IndexError:
-        usage('original branch and version required (e.g. master:82)')
+        usage('original branch and version required (e.g. main:82)')
 
     try:
         new_branch, new_version = sys.argv[3].split(':')
     except IndexError:
-        usage('new branch and version required (e.g. master:82)')
+        usage('new branch and version required (e.g. main:82)')
 
     return db_url, orig_branch, orig_version, new_branch, new_version
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.